### PR TITLE
Ad insert speedup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,12 @@ migrations
 fbconnector/drafts
 .idea/*
 *.pyc
+.vscode
+
+# virtualenv resources
+bin
+include
+lib
 
 # Elastic Beanstalk Files
 .elasticbeanstalk/*

--- a/app/utils/ad_inserter.py
+++ b/app/utils/ad_inserter.py
@@ -1,0 +1,258 @@
+from app import db
+from app.service.models import Adverts, Advertisers, Impressions, Demographic_distribution, Region_distribution
+from app.utils.functions import cast_date, extract_id, parse_bounds, parse_distr, finished_main_scripts
+from datetime import datetime
+from flask import current_app as app
+from sqlalchemy import create_engine
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.sql import select, text
+
+# fixed size advert dict for core bulk insert
+def advert_dict(fb_ad, country):
+    return {   
+        'ad_creation_time': fb_ad.get('ad_creation_time', None),
+        'ad_creative_body': fb_ad.get('ad_creative_body', None),
+        'ad_creative_link_caption': fb_ad.get('ad_creative_link_caption', None),
+        'ad_creative_link_description': fb_ad.get('ad_creative_link_description', None),
+        'ad_creative_link_title': fb_ad.get('ad_creative_link_title', None),
+        'ad_delivery_start_time': fb_ad.get('ad_delivery_start_time', None),
+        'ad_delivery_stop_time': fb_ad.get('ad_delivery_stop_time', None),
+        'ad_info': fb_ad.get('ad_info', None),
+        'ad_snapshot_url': fb_ad.get('ad_snapshot_url', None),
+        'country': country,
+        'currency': fb_ad.get('currency', None),
+        'funding_entity': fb_ad.get('funding_entity', None),
+        'image_link': fb_ad.get('image_link', None),
+        'page_id': fb_ad.get('page_id', None),
+        'page_name': fb_ad.get('page_name', None),
+        'post_id': extract_id(fb_ad.get('ad_snapshot_url'))
+    }
+
+
+def bulk_insert_adverts(fb_ads, country):
+    # executemany_mode - https://docs.sqlalchemy.org/en/13/dialects/postgresql.html#psycopg2-fast-execution-helpers
+    engine = create_engine(app.config['SQLALCHEMY_DATABASE_URI'], echo=False, executemany_mode='batch')
+    connection = engine.connect()
+
+    # BULK INSERT 
+    # https://docs.sqlalchemy.org/en/13/_modules/examples/performance/bulk_inserts.html
+    # https://github.com/zzzeek/sqlalchemy/blob/master/doc/build/faq/performance.rst#user-content-i-m-inserting-400-000-rows-with-the-orm-and-it-s-really-slow
+    #
+    # Compose an insert statement we can pass in to execut with a dictionary of items. 
+    #   - generic insert: Adverts.__table__.insert(),
+    #   - postgres insert: pg_insert(Adverts.__table__).on_conflict_do_nothing(),
+    #   - or... insert or update selected columns using posgres ON CONFLICT
+    #
+    # INSERT INTO advertisers (post_id, country, page_name)
+    # VALUES ($1, $2, $3)
+    # ON CONFLICT (post_id)
+    # DO UPDATE SET
+    # 	page_name=$3
+    # ;
+    statement = pg_insert(Adverts.__table__)
+    statement = statement.on_conflict_do_update(
+            constraint='adverts_post_id_key',
+            set_={
+                'ad_delivery_stop_time': statement.excluded.ad_delivery_stop_time,
+                'updated_at': datetime.now() # this will always set... do we want that?
+            }
+        )
+    
+    connection.execute(
+        statement,
+        [advert_dict(a, country) for a in fb_ads]
+    )
+
+    # executemany in psycopg2 doesn't return the value for all rows (even if you 
+    # include a returning statement... like it would in PgSQL... 🤔). 
+    # So we need to refetch this inserted data
+
+    # get post_ids to lookup from db... set struct saves removing dupes
+    fb_ads_post_ids = { extract_id(ad['ad_snapshot_url']) for ad in fb_ads }
+    
+    results = connection.execute(
+            select(
+                [Adverts.__table__.columns.id, Adverts.__table__.columns.post_id], 
+                Adverts.__table__.columns.post_id.in_(fb_ads_post_ids)
+            )
+        ).fetchall()
+
+    # reformat to look kinda like you'd expect [{'id':1, 'post_id':234}]
+    adverts = [dict(id=r[0], post_id=r[1]) for r in results]
+    
+    return adverts
+
+
+def impression_dict(fb_ad, advert_id, country): 
+    lower_bound_impressions, upper_bound_impressions = parse_bounds(fb_ad.get('impressions', None))
+    lower_bound_spend, upper_bound_spend = parse_bounds(fb_ad.get('spend', None))
+
+    return {
+        'advert_id': advert_id,
+        'country': country,
+        'demographic_distribution': fb_ad.get('demographic_distribution', None),
+        'impressions': fb_ad.get('impressions', None),
+        'lower_bound_impressions': lower_bound_impressions,
+        'lower_bound_spend': lower_bound_spend,
+        'page_id': fb_ad.get('page_id', None),
+        'post_id': extract_id(fb_ad.get('ad_snapshot_url')),
+        'region_distribution': fb_ad.get('region_distribution', None),
+        'spend': fb_ad.get('spend', None),
+        'upper_bound_impressions': upper_bound_impressions,
+        'upper_bound_spend': upper_bound_spend
+    }
+  
+            
+def bulk_insert_impressions(fb_ads, adverts, country):
+    engine = create_engine(app.config['SQLALCHEMY_DATABASE_URI'], echo=False, executemany_mode='batch')
+    connection = engine.connect()
+
+    # we want existing the ads so we can match up the advert_id
+    # this will be much easier if we have a hash table
+    post_advert_id_map = {a['post_id']:a['id'] for a in adverts}
+
+    # build impressions to insert
+    impressions = []
+    for fb_ad in fb_ads:
+        # We stop adding impression data when we have ad_delivery_stop_time
+        # FIXME: we need to check the stop time and recording impressions until then
+        if not skip_ad(fb_ad):
+            post_id = extract_id(fb_ad.get('ad_snapshot_url'))
+            ad_id = post_advert_id_map.get(post_id)
+            impressions.append(impression_dict(fb_ad, ad_id, country))
+        
+    connection.execute(
+        pg_insert(Impressions.__table__).returning(Impressions.__table__.columns.id),
+        impressions
+    )
+    
+    # get result again... would be much simpler if psycopg2 respected returning.
+    # we need to do some filtering by latest for these post_ids
+    statement = text("""SELECT id, advert_id, post_id, created_at
+                    FROM impressions JOIN
+                        (SELECT MAX(created_at) created_at, post_id 
+                            FROM impressions 
+                            WHERE post_id IN :fb_ads_post_ids
+                            GROUP BY post_id 
+                        ) AS max_date
+                    USING (post_id, created_at)""")
+
+    fb_ads_post_ids = { extract_id(ad['ad_snapshot_url']) for ad in fb_ads }
+
+    results = connection.execute(
+            statement,
+            fb_ads_post_ids=tuple(fb_ads_post_ids) # tuple generates (1,2,3) output for IN
+        ).fetchall()
+
+    # reformat to look like you'd expect [{'id':1, 'advert_id':234, ... etc }]
+    impressions = []
+    for r in results:
+        impressions.append(dict(id=r[0], advert_id=r[1], post_id=r[2], created_at=r[3]))
+    
+    return impressions
+
+
+def demographic_distributions_dict(fb_demographic_distribution, impression_id): 
+    percentage, age, gender = parse_distr(fb_demographic_distribution, 'dem')
+    return {
+        'age': age,
+        'gender': gender,
+        'impression_id': impression_id,
+        'percentage': percentage
+    }
+
+
+def bulk_insert_demographic_distributions(fb_ads, impressions):
+    engine = create_engine(app.config['SQLALCHEMY_DATABASE_URI'], echo=False, executemany_mode='batch')
+    connection = engine.connect()
+
+    post_impression_id_map = {i['post_id']:i['id'] for i in impressions}
+
+    demographic_distributions = []
+    for fb_ad in fb_ads:
+        if not skip_ad(fb_ad):
+            fb_demographic_distribution = fb_ad.get('demographic_distribution', None)
+            post_id = extract_id(fb_ad.get('ad_snapshot_url'))
+            impression_id = post_impression_id_map.get(post_id)
+
+            # iterate demographic_distribution field
+            for dd in fb_demographic_distribution:
+                demographic_distributions.append(
+                        demographic_distributions_dict(
+                            dd, 
+                            impression_id
+                        )
+                    )
+    
+    connection.execute(
+        Demographic_distribution.__table__.insert(),
+        demographic_distributions
+    )
+
+    # We don't really need return values here
+    return 'OK'
+
+
+def region_distributions_dict(fb_region_distribution, impression_id): 
+    percentage, region = parse_distr(fb_region_distribution, 'reg')
+    return {
+        'impression_id': impression_id,
+        'percentage': percentage,
+        'region': region
+    }
+
+def bulk_insert_region_distributions(fb_ads, impressions):
+    engine = create_engine(app.config['SQLALCHEMY_DATABASE_URI'], echo=False, executemany_mode='batch')
+    connection = engine.connect()
+
+    post_impression_id_map = {i['post_id']:i['id'] for i in impressions}
+
+    region_distributions = []
+    for fb_ad in fb_ads:
+        if not skip_ad(fb_ad):
+            fb_region_distribution = fb_ad.get('region_distribution', None)
+            post_id = extract_id(fb_ad.get('ad_snapshot_url'))
+            impression_id = post_impression_id_map.get(post_id)
+
+            # iterate region_distribution field
+            for dd in fb_region_distribution:
+                region_distributions.append(
+                        region_distributions_dict(
+                            dd, 
+                            impression_id
+                        )
+                    )
+    
+    connection.execute(
+        Region_distribution.__table__.insert(),
+        region_distributions
+    )
+
+    # We don't really need return values here
+    return 'OK'
+
+
+
+# utils
+def skip_ad(fb_ad):
+    should_skip = False
+
+    # check if the ad's run has finished
+    # FIXME - this should compare date
+    should_skip = bool(fb_ad.get('ad_delivery_stop_time', False))
+
+    return should_skip
+
+
+# Main
+def parse_and_insert(fb_ads, country):
+
+    adverts = bulk_insert_adverts(fb_ads, country)
+
+    impressions = bulk_insert_impressions(fb_ads, adverts, country)
+
+    bulk_insert_demographic_distributions(fb_ads, impressions)
+
+    bulk_insert_region_distributions(fb_ads, impressions)
+
+    return

--- a/application.py
+++ b/application.py
@@ -1,22 +1,23 @@
 from app import create_app, db
-from app.service.models import Advertisers, Tokens
-
-import sys
-from apscheduler.schedulers.background import BackgroundScheduler
 from app.fbconnector.ad_downloader import download_ads
 from app.service.models import Advertisers, Adverts, Tokens
-from app.utils.loader import parse_and_load_adverts
+from app.service.models import Advertisers, Tokens
+from app.utils.ad_inserter import parse_and_insert
 from app.utils.functions import finished_main_scripts
-from flask import render_template, request, session, g, jsonify
-from flask import current_app as ap
-from sqlalchemy import exc, func
-import requests
+from app.utils.loader import parse_and_load_adverts
+from apscheduler.schedulers.background import BackgroundScheduler
 from datetime import datetime
+from flask import current_app as ap
+from flask import render_template, request, session, g, jsonify
+from sqlalchemy import exc, func
+import os
+import requests
+import sys
 
 def call_loader(country='GB'):
     with application.app_context():
         print('starting loading job', datetime.now())
-        single_call_lst = []
+        
         # Get config to make request to FB library
         API_VERSION = ap.config['API_VERSION']
         PAGES_BETWEEN_STORING = ap.config['PAGES_BETWEEN_STORING']
@@ -24,16 +25,25 @@ def call_loader(country='GB'):
         latest_record = db.session.query(Tokens).order_by(Tokens.id.desc()).first()
         LONG_TOKEN = latest_record.long_token
 
+        # get our predefined advertisers
         advertisers = Advertisers.query.all()
-        IDS = [int(a.page_id) for a in advertisers if a.country == country]
+        advertiser_ids = [int(a.page_id) for a in advertisers if a.country == country]
+        
+        # get the most frequent advertisers, based on previously saved adverts
+        single_call_lst = []
         adverts = db.session.query(Adverts.page_id, func.count(Adverts.page_id)).group_by(Adverts.page_id).all()
         single_call_lst = [int(a[0]) for a in adverts if a[1] < (ADS_PER_PAGE - 100)]
+        ordered_ids = sorted([a for a in adverts], key=lambda k: k[1], reverse=True)
+        frequent_advertiser_ids = [int(a[0]) for a in ordered_ids][:2] #50
+
+        # select which advertiser ids set to use, based on... time of day?
         if finished_main_scripts():
-            ordered_ids = sorted([a for a in adverts], key=lambda k: k[1], reverse=True)
-            IDS = [int(a[0]) for a in ordered_ids][:2] #50
+            IDS = frequent_advertiser_ids
+        else:
+            IDS = advertiser_ids
+
         print('FETCHING IDS ...', IDS)
         print('single_call_lst', single_call_lst)
-
 
         for ID in IDS:
             # Iteratively download and store ads
@@ -44,8 +54,11 @@ def call_loader(country='GB'):
                 print('...CRON...Starting download from FB library.................', ID, 'time=', datetime.now())
                 body, next_page = download_ads(API_VERSION, LONG_TOKEN,\
                     PAGES_BETWEEN_STORING, ADS_PER_PAGE, [ID], country, next_page, single_call)
+                
                 print('...CRON.....Uploading data to DB....................', ID, 'page=', page, 'time=', datetime.now())
-                parse_and_load_adverts(body, country)
+                # parse_and_load_adverts(body, country)
+                parse_and_insert(body, country)
+
                 page += 1
             print('...CRON...Finished upload to db.............................', ID, 'time=', datetime.now())
         return '<h1> Advertisers: {0} </h1>'.format(IDS)
@@ -54,7 +67,7 @@ def call_loader(country='GB'):
 #     raise ValueError("Pls provide ENV")
 
 PARAMS = {
-    'ENV': 'prod' # 'dev', 'prod'
+    'ENV': os.getenv("ENV", 'prod') # 'dev', 'prod'
 }
 try:
     for i, arg in enumerate(sys.argv):

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ docker-pycreds==0.4.0
 dockerpty==0.4.1
 docopt==0.6.2
 docutils==0.15.2
-ffacebook-sdk==3.1.0
+facebook-sdk==3.1.0
 Flask==1.1.1
 Flask-APScheduler==1.11.0
 Flask-Migrate==2.5.2
@@ -38,7 +38,7 @@ numpy==1.17.2
 pandas==0.25.1
 pathspec==0.5.9
 Pillow==6.2.0
-psycopg2==2.8.3
+psycopg2==2.8.4
 pyasn1==0.4.7
 python-dateutil==2.8.0
 python-editor==1.0.4
@@ -51,7 +51,7 @@ selenium==3.141.0
 semantic-version==2.5.0
 six==1.11.0
 soupsieve==1.9.4
-SQLAlchemy==1.3.8
+SQLAlchemy==1.3.11
 termcolor==1.1.0
 texttable==0.9.1
 tzlocal==2.0.0


### PR DESCRIPTION
A significant refactor of ad insert code to use SQLAlchemy core.

- 4x speedup seen on single advertiser with 2688 ads
- Noticable memory reduction... ~100MB less per 2000 ads: