### PR TITLE
Add migrations. Add further specificity to model unique constraint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,8 @@
 _run.py
-*/__pycache__/
+**/__pycache__/
 .DS_Store
 config/dev.py
 config/aws.py
-migrations
 fbconnector/drafts
 .idea/*
 *.pyc

--- a/app/service/models.py
+++ b/app/service/models.py
@@ -125,9 +125,9 @@ class Impressions(db.Model):
     post_id = db.Column(db.String(25), nullable=False, index=True)
     country = db.Column(db.String(10), nullable=False) # GB,US...
     demographic_distribution = db.Column(db.JSON, nullable=True) #raw value
-    _demographic_distribution_text = db.Column(db.Text)
+    _demographic_distribution_hash = db.Column(db.Text)
     region_distribution = db.Column(db.JSON, nullable=True) #raw value
-    _region_distribution_text = db.Column(db.Text)
+    _region_distribution_hash = db.Column(db.Text)
     impressions = db.Column(JSONEncodedDict, nullable=True) #raw value
     spend = db.Column(JSONEncodedDict, nullable=True) #raw value
     lower_bound_impressions = db.Column(db.String(25), nullable=True) #parsed
@@ -140,7 +140,7 @@ class Impressions(db.Model):
     rd = relationship("Region_distribution", cascade="all, delete-orphan", backref='impressions')
 
     __table_args__ = (
-        UniqueConstraint('post_id', 'impressions', 'spend', '_region_distribution_text', '_demographic_distribution_text', 
+        UniqueConstraint('post_id', 'impressions', 'spend', '_region_distribution_hash', '_demographic_distribution_hash', 
             name='ix_unique_post_id_impressions_spend_region_demographic'),
         )
 

--- a/migrations/README
+++ b/migrations/README
@@ -1,0 +1,1 @@
+Generic single-database configuration.

--- a/migrations/alembic.ini
+++ b/migrations/alembic.ini
@@ -1,0 +1,45 @@
+# A generic, single database configuration.
+
+[alembic]
+# template used to generate migration files
+# file_template = %%(rev)s_%%(slug)s
+
+# set to 'true' to run the environment during
+# the 'revision' command, regardless of autogenerate
+# revision_environment = false
+
+
+# Logging configuration
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -1,0 +1,96 @@
+from __future__ import with_statement
+
+import logging
+from logging.config import fileConfig
+
+from sqlalchemy import engine_from_config
+from sqlalchemy import pool
+
+from alembic import context
+
+# this is the Alembic Config object, which provides
+# access to the values within the .ini file in use.
+config = context.config
+
+# Interpret the config file for Python logging.
+# This line sets up loggers basically.
+fileConfig(config.config_file_name)
+logger = logging.getLogger('alembic.env')
+
+# add your model's MetaData object here
+# for 'autogenerate' support
+# from myapp import mymodel
+# target_metadata = mymodel.Base.metadata
+from flask import current_app
+config.set_main_option(
+    'sqlalchemy.url', current_app.config.get(
+        'SQLALCHEMY_DATABASE_URI').replace('%', '%%'))
+target_metadata = current_app.extensions['migrate'].db.metadata
+
+# other values from the config, defined by the needs of env.py,
+# can be acquired:
+# my_important_option = config.get_main_option("my_important_option")
+# ... etc.
+
+
+def run_migrations_offline():
+    """Run migrations in 'offline' mode.
+
+    This configures the context with just a URL
+    and not an Engine, though an Engine is acceptable
+    here as well.  By skipping the Engine creation
+    we don't even need a DBAPI to be available.
+
+    Calls to context.execute() here emit the given string to the
+    script output.
+
+    """
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(
+        url=url, target_metadata=target_metadata, literal_binds=True
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online():
+    """Run migrations in 'online' mode.
+
+    In this scenario we need to create an Engine
+    and associate a connection with the context.
+
+    """
+
+    # this callback is used to prevent an auto-migration from being generated
+    # when there are no changes to the schema
+    # reference: http://alembic.zzzcomputing.com/en/latest/cookbook.html
+    def process_revision_directives(context, revision, directives):
+        if getattr(config.cmd_opts, 'autogenerate', False):
+            script = directives[0]
+            if script.upgrade_ops.is_empty():
+                directives[:] = []
+                logger.info('No changes in schema detected.')
+
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section),
+        prefix='sqlalchemy.',
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(
+            connection=connection,
+            target_metadata=target_metadata,
+            process_revision_directives=process_revision_directives,
+            **current_app.extensions['migrate'].configure_args
+        )
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/migrations/script.py.mako
+++ b/migrations/script.py.mako
@@ -1,0 +1,24 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision = ${repr(up_revision)}
+down_revision = ${repr(down_revision)}
+branch_labels = ${repr(branch_labels)}
+depends_on = ${repr(depends_on)}
+
+
+def upgrade():
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade():
+    ${downgrades if downgrades else "pass"}

--- a/migrations/versions/6c6cc9aba03c_.py
+++ b/migrations/versions/6c6cc9aba03c_.py
@@ -1,0 +1,52 @@
+"""empty message
+
+Revision ID: 6c6cc9aba03c
+Revises: 785df91f72ae
+Create Date: 2020-02-05 12:08:21.475859
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '6c6cc9aba03c'
+down_revision = '785df91f72ae'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    
+    op.create_unique_constraint('ix_unique_impression_id_age_gender_percentage', 'demographic_distribution', ['impression_id', 'age', 'gender', 'percentage'])
+    op.add_column('impressions', sa.Column('_demographic_distribution_hash', sa.Text(), nullable=True))
+    op.add_column('impressions', sa.Column('_region_distribution_hash', sa.Text(), nullable=True))
+    op.create_unique_constraint('ix_unique_post_id_impressions_spend_region_demographic', 'impressions', ['post_id', 'impressions', 'spend', '_region_distribution_hash', '_demographic_distribution_hash'])
+    op.create_unique_constraint('ix_unique_impression_id_region_percentage', 'region_distribution', ['impression_id', 'region', 'percentage'])
+    op.execute("""
+      CREATE OR REPLACE FUNCTION serialize_impression_region_demographic ()
+          RETURNS TRIGGER
+          AS $BODY$
+      BEGIN
+          NEW._region_distribution_hash = MD5(NEW.region_distribution::text);
+          NEW._demographic_distribution_hash = MD5(NEW.demographic_distribution::text);
+          RETURN NEW;
+      END;
+      $BODY$
+      LANGUAGE 'plpgsql';
+    """)
+    op.execute("""
+      CREATE TRIGGER serialize_impression_region_demographic
+          BEFORE INSERT OR UPDATE ON impressions
+          FOR EACH ROW
+          EXECUTE PROCEDURE serialize_impression_region_demographic ();
+    """)
+
+def downgrade():
+    op.drop_constraint('ix_unique_impression_id_region_percentage', 'region_distribution', type_='unique')
+    op.drop_constraint('ix_unique_post_id_impressions_spend_region_demographic', 'impressions', type_='unique')
+    op.drop_column('impressions', '_region_distribution_hash')
+    op.drop_column('impressions', '_demographic_distribution_hash')
+    op.drop_constraint('ix_unique_impression_id_age_gender_percentage', 'demographic_distribution', type_='unique')
+    op.execute("DROP TRIGGER IF EXISTS serialize_impression_region_demographic ON impressions")
+    op.execute("DROP FUNCTION IF EXISTS serialize_impression_region_demographic()")

--- a/migrations/versions/785df91f72ae_.py
+++ b/migrations/versions/785df91f72ae_.py
@@ -1,0 +1,43 @@
+"""Add text_search column to adverts
+
+Revision ID: 785df91f72ae
+Revises: de807a8d292f
+Create Date: 2020-02-05 11:41:08.223905
+
+"""
+from alembic import op
+from sqlalchemy.dialects import postgresql
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '785df91f72ae'
+down_revision = 'de807a8d292f'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('adverts', sa.Column('text_search', postgresql.TSVECTOR(), nullable=True))
+    op.execute("""
+      CREATE OR REPLACE FUNCTION text_to_vector ()
+          RETURNS trigger
+          LANGUAGE 'plpgsql'
+      AS $BODY$
+          BEGIN
+              NEW."text_search" := to_tsvector(concat(NEW.ad_creative_body, ' ', NEW.ad_creative_link_description, ' ', NEW.ad_creative_link_title));
+              RETURN NEW;
+          END;
+      $BODY$;
+    """)
+    op.execute("""
+      CREATE TRIGGER text_to_vector
+        BEFORE INSERT OR UPDATE ON adverts
+        FOR EACH ROW
+        EXECUTE PROCEDURE text_to_vector ();
+    """)
+    
+
+def downgrade():
+    op.drop_column('adverts', 'text_search')
+    op.execute("DROP TRIGGER IF EXISTS text_to_vector ON adverts")
+    op.execute("DROP FUNCTION IF EXISTS text_to_vector()")

--- a/migrations/versions/de807a8d292f_.py
+++ b/migrations/versions/de807a8d292f_.py
@@ -1,0 +1,154 @@
+"""Initial setup
+
+Revision ID: de807a8d292f
+Revises: 
+Create Date: 2020-02-05 10:53:05.723121
+
+"""
+from alembic import op
+from app.service.models import JSONEncodedDict
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'de807a8d292f'
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table('advertisers',
+      sa.Column('id', sa.Integer(), nullable=False),
+      sa.Column('page_id', sa.String(length=25), nullable=False),
+      sa.Column('page_name', sa.Text(), nullable=True),
+      sa.Column('country', sa.String(length=10), nullable=False),
+      sa.Column('created_at', sa.DateTime(timezone=True), nullable=True),
+      sa.Column('updated_at', sa.DateTime(timezone=True), nullable=True),
+      sa.PrimaryKeyConstraint('id'),
+      sa.UniqueConstraint('page_id')
+    )
+    op.create_index(op.f('ix_advertisers_page_name'), 'advertisers', ['page_name'], unique=False)
+
+    op.create_table('adverts',
+      sa.Column('id', sa.Integer(), nullable=False),
+      sa.Column('page_id', sa.String(length=25), nullable=False),
+      sa.Column('page_name', sa.Text(), nullable=True),
+      sa.Column('post_id', sa.String(length=25), nullable=False),
+      sa.Column('country', sa.String(length=10), nullable=False),
+      sa.Column('ad_creation_time', sa.DateTime(timezone=True), nullable=True),
+      sa.Column('ad_creative_body', sa.Text(), nullable=True),
+      sa.Column('ad_creative_link_caption', sa.Text(), nullable=True),
+      sa.Column('ad_creative_link_description', sa.Text(), nullable=True),
+      sa.Column('ad_creative_link_title', sa.Text(), nullable=True),
+      sa.Column('ad_delivery_start_time', sa.DateTime(timezone=True), nullable=True),
+      sa.Column('ad_delivery_stop_time', sa.DateTime(timezone=True), nullable=True),
+      sa.Column('ad_snapshot_url', sa.Text(), nullable=True),
+      sa.Column('image_link', sa.Text(), nullable=True),
+      sa.Column('currency', sa.String(length=10), nullable=True),
+      sa.Column('funding_entity', sa.Text(), nullable=True),
+      sa.Column('ad_info', JSONEncodedDict(), nullable=True),
+      sa.Column('created_at', sa.DateTime(timezone=True), nullable=True),
+      sa.Column('updated_at', sa.DateTime(timezone=True), nullable=True),
+      sa.PrimaryKeyConstraint('id'),
+      sa.UniqueConstraint('post_id')
+    )
+    op.create_index(op.f('ix_adverts_ad_delivery_start_time'), 'adverts', ['ad_delivery_start_time'], unique=False)
+    op.create_index(op.f('ix_adverts_funding_entity'), 'adverts', ['funding_entity'], unique=False)
+    op.create_index(op.f('ix_adverts_page_name'), 'adverts', ['page_name'], unique=False)
+
+    op.create_table('tokens',
+      sa.Column('id', sa.Integer(), nullable=False),
+      sa.Column('short_token', sa.Text(), nullable=False),
+      sa.Column('long_token', sa.Text(), nullable=True),
+      sa.Column('short_last_updated_at', sa.DateTime(timezone=True), nullable=True),
+      sa.Column('long_last_updated_at', sa.DateTime(timezone=True), nullable=True),
+      sa.Column('long_token_expires_on', sa.DateTime(timezone=True), nullable=True),
+      sa.PrimaryKeyConstraint('id'),
+      sa.UniqueConstraint('long_token'),
+      sa.UniqueConstraint('short_token')
+    )
+
+    op.create_table('impressions',
+      sa.Column('id', sa.Integer(), nullable=False),
+      sa.Column('advert_id', sa.Integer(), nullable=False),
+      sa.Column('page_id', sa.String(length=25), nullable=False),
+      sa.Column('post_id', sa.String(length=25), nullable=False),
+      sa.Column('country', sa.String(length=10), nullable=False),
+      sa.Column('demographic_distribution', sa.JSON(), nullable=True),
+      sa.Column('region_distribution', sa.JSON(), nullable=True),
+      sa.Column('impressions', JSONEncodedDict(), nullable=True),
+      sa.Column('spend', JSONEncodedDict(), nullable=True),
+      sa.Column('lower_bound_impressions', sa.String(length=25), nullable=True),
+      sa.Column('upper_bound_impressions', sa.String(length=25), nullable=True),
+      sa.Column('lower_bound_spend', sa.String(length=25), nullable=True),
+      sa.Column('upper_bound_spend', sa.String(length=25), nullable=True),
+      sa.Column('created_at', sa.DateTime(timezone=True), nullable=True),
+      sa.Column('updated_at', sa.DateTime(timezone=True), nullable=True),
+      sa.ForeignKeyConstraint(['advert_id'], ['adverts.id'], ),
+      sa.PrimaryKeyConstraint('id')
+    )
+    op.create_index(op.f('ix_impressions_advert_id'), 'impressions', ['advert_id'], unique=False)
+    op.create_index(op.f('ix_impressions_page_id'), 'impressions', ['page_id'], unique=False)
+    op.create_index(op.f('ix_impressions_post_id'), 'impressions', ['post_id'], unique=False)
+
+    op.create_table('media',
+      sa.Column('id', sa.Integer(), nullable=False),
+      sa.Column('advert_id', sa.Integer(), nullable=False),
+      sa.Column('www_links', sa.JSON(), nullable=True),
+      sa.Column('aws_links', sa.JSON(), nullable=True),
+      sa.Column('created_at', sa.DateTime(timezone=True), nullable=True),
+      sa.Column('updated_at', sa.DateTime(timezone=True), nullable=True),
+      sa.ForeignKeyConstraint(['advert_id'], ['adverts.id'], ),
+      sa.PrimaryKeyConstraint('id')
+    )
+    op.create_index(op.f('ix_media_advert_id'), 'media', ['advert_id'], unique=False)
+
+    op.create_table('demographic_distribution',
+      sa.Column('id', sa.Integer(), nullable=False),
+      sa.Column('impression_id', sa.Integer(), nullable=False),
+      sa.Column('percentage', sa.Float(), nullable=True),
+      sa.Column('age', sa.String(length=10), nullable=True),
+      sa.Column('gender', sa.String(length=10), nullable=True),
+      sa.Column('created_at', sa.DateTime(timezone=True), nullable=True),
+      sa.Column('updated_at', sa.DateTime(timezone=True), nullable=True),
+      sa.ForeignKeyConstraint(['impression_id'], ['impressions.id'], ),
+      sa.PrimaryKeyConstraint('id')
+    )
+    op.create_index(op.f('ix_demographic_distribution_impression_id'), 'demographic_distribution', ['impression_id'], unique=False)
+    
+    op.create_table('region_distribution',
+      sa.Column('id', sa.Integer(), nullable=False),
+      sa.Column('impression_id', sa.Integer(), nullable=False),
+      sa.Column('percentage', sa.Float(), nullable=True),
+      sa.Column('region', sa.String(length=255), nullable=True),
+      sa.Column('created_at', sa.DateTime(timezone=True), nullable=True),
+      sa.Column('updated_at', sa.DateTime(timezone=True), nullable=True),
+      sa.ForeignKeyConstraint(['impression_id'], ['impressions.id'], ),
+      sa.PrimaryKeyConstraint('id')
+    )
+    op.create_index(op.f('ix_region_distribution_impression_id'), 'region_distribution', ['impression_id'], unique=False)
+    op.create_index(op.f('ix_region_distribution_region'), 'region_distribution', ['region'], unique=False)
+    # ### end Alembic commands ###
+
+
+def downgrade():
+    # ### commands auto generated by Alembic - please adjust! ###
+    op.drop_index(op.f('ix_region_distribution_region'), table_name='region_distribution')
+    op.drop_index(op.f('ix_region_distribution_impression_id'), table_name='region_distribution')
+    op.drop_table('region_distribution')
+    op.drop_index(op.f('ix_demographic_distribution_impression_id'), table_name='demographic_distribution')
+    op.drop_table('demographic_distribution')
+    op.drop_index(op.f('ix_media_advert_id'), table_name='media')
+    op.drop_table('media')
+    op.drop_index(op.f('ix_impressions_post_id'), table_name='impressions')
+    op.drop_index(op.f('ix_impressions_page_id'), table_name='impressions')
+    op.drop_index(op.f('ix_impressions_advert_id'), table_name='impressions')
+    op.drop_table('impressions')
+    op.drop_table('tokens')
+    op.drop_index(op.f('ix_adverts_page_name'), table_name='adverts')
+    op.drop_index(op.f('ix_adverts_funding_entity'), table_name='adverts')
+    op.drop_index(op.f('ix_adverts_ad_delivery_start_time'), table_name='adverts')
+    op.drop_table('adverts')
+    op.drop_index(op.f('ix_advertisers_page_name'), table_name='advertisers')
+    op.drop_table('advertisers')
+    # ### end Alembic commands ###


### PR DESCRIPTION
Add further specificity to impressions/distribution constraints.

Setup migrations
- Initial setup migration
- Add text_search column and postgres trigger function
- Add impression, distribution constraints and trigger functions